### PR TITLE
BugFixes on only reflecting GMT #36

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,13 @@
   "extends": "airbnb-base",
   "env": {
     "jest": true
+  },
+  "rules": {
+    "no-console": 0,
+    "no-debugger": 1,
+    "no-duplicate-case": 2,
+    "no-empty-character-class": 2,
+    "no-empty": 2,
+    "semi": 2
   }
 }

--- a/src/getDailySummary.js
+++ b/src/getDailySummary.js
@@ -4,7 +4,7 @@ import setup from './setup';
 import { get } from './services/apiKeyStore';
 import generateDailySummary from './services/generateDailySummary';
 
-const getDailySummary = async (date = ''+new Date()) => {
+const getDailySummary = async (date = new Date()) => {
   let apiKey = await get();
 
   if (!apiKey) {
@@ -13,7 +13,7 @@ const getDailySummary = async (date = ''+new Date()) => {
   }
 
   // PAGING DR.HACKY AS FUCK, PAGING DR.HACKY AS FUCK
-  const formattedDate = date.toISOString().split('T')[0];
+  const formattedDate = date.toLocaleDateString();
 
   const client = new WakaTimeClient(apiKey);
   const summary = await client.getMySummary({

--- a/src/getDailySummary.js
+++ b/src/getDailySummary.js
@@ -4,7 +4,7 @@ import setup from './setup';
 import { get } from './services/apiKeyStore';
 import generateDailySummary from './services/generateDailySummary';
 
-const getDailySummary = async (date = new Date()) => {
+const getDailySummary = async (date = ''+new Date()) => {
   let apiKey = await get();
 
   if (!apiKey) {

--- a/src/getWeeklySummary.js
+++ b/src/getWeeklySummary.js
@@ -12,8 +12,8 @@ const getWeeklySummary = async () => {
     apiKey = await get();
   }
 
-  const startDate = new Date(new Date().setDate(new Date().getDate() - 6));
-  const endDate = new Date();
+  const startDate = new Date(new Date().setDate(('' + new Date()).getDate() - 6));
+  const endDate = '' + new Date();
   const formattedStartDate = startDate.toISOString().split('T')[0];
   const formattedEndDate = endDate.toISOString().split('T')[0];
 

--- a/src/getWeeklySummary.js
+++ b/src/getWeeklySummary.js
@@ -12,10 +12,10 @@ const getWeeklySummary = async () => {
     apiKey = await get();
   }
 
-  const startDate = new Date(new Date().setDate(('' + new Date()).getDate() - 6));
-  const endDate = '' + new Date();
-  const formattedStartDate = startDate.toISOString().split('T')[0];
-  const formattedEndDate = endDate.toISOString().split('T')[0];
+  const startDate = new Date(new Date().setDate(new Date().getDate() - 6));
+  const endDate = new Date();
+  const formattedStartDate = startDate.toLocaleDateString();
+  const formattedEndDate = endDate.toLocaleDateString();
 
   const client = new WakaTimeClient(apiKey);
   const summary = await client.getMySummary({


### PR DESCRIPTION
With the inclusion of '' in front of every Date.now(), the time used in CLI can now correctly reflect the user's local time on DailySummary and WeeklySummary.