### PR TITLE
feat(filters): filter for output sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
   - [Usage](#usage)
     - [Setup](#setup)
     - [Summary Options](#summary-options)
+    - [Section Filters](#section-filters)
+    - [Section Options](#section-options)
     - [Today's Summary](#todays-summary)
     - [Footnotes](#footnotes)
 
@@ -46,6 +48,8 @@ Then, use the `waka setup` command to set your API key for the `wakatimecli` pro
 
 ### Summary Options
 
+### Section Filters
+
 There are a couple notable command line options for filtering summary data.
 
 However, filtering only impacts the summary data for the given section. So filtering by a particular project name will only change the output data for the `Projects` section and won't impact the `Editors` or `Languages` section.
@@ -58,6 +62,16 @@ This is primarily due to the output from the Wakatime `/summaries` endpoint whic
   - Supports regex, so `-l /java.*/i`, for example (which would match `Java` and `JavaScript`)
 - `-p <Some Projects Filter>` - filters the projects in the `Projects` section
   - Supports regex, so `-p /waka.*/i`, for example (which would match `wakatime-cli` and `wakatime-client`)
+
+### Section Options
+
+You might want to restrict the sections that are outputted (if you want to _only_ see your language statistics, for example).
+
+Here are the following ways to toggle specific sections. If no options are specified, **all sections** will be displayed.
+
+- `-E` - show the `Editors` section
+- `-L` - show the `Languages` section
+- `-P` - show the `Projects` section
 
 ### Today's Summary
 

--- a/src/executables/waka.js
+++ b/src/executables/waka.js
@@ -19,8 +19,11 @@ program
 program
   .command('today')
   .description('Get Daily Summary')
+  .option('-E, --showEditors', 'Show editors section')
   .option('-e, --editorsFilter <editorFilter>', 'Filter editors by their name using regex')
+  .option('-L, --showLanguages', 'Show languages section')
   .option('-l, --languagesFilter <languagesFilter>', 'Filters languages by their name using regex')
+  .option('-P, --showProjects', 'Show projects section')
   .option('-p, --projectsFilter <projectsFilter', 'Filters projects by their name using regex')
   .action(async (args) => {
     try {
@@ -28,6 +31,9 @@ program
         editorsFilter: args.editorsFilter,
         languagesFilter: args.languagesFilter,
         projectsFilter: args.projectsFilter,
+        showEditors: args.showEditors,
+        showLanguages: args.showLanguages,
+        showProjects: args.showProjects,
       });
     } catch (error) {
       console.error('😞  Rut ro, an error occurred');
@@ -38,8 +44,11 @@ program
 program
   .command('yesterday')
   .description('Get Summary for Yesterday')
+  .option('-E, --showEditors', 'Show editors section')
   .option('-e, --editorsFilter <editorFilter>', 'Filter editors by their name using regex')
+  .option('-L, --showLanguages', 'Show languages section')
   .option('-l, --languagesFilter <languagesFilter>', 'Filters languages by their name using regex')
+  .option('-P, --showProjects', 'Show projects section')
   .option('-p, --projectsFilter <projectsFilter', 'Filters projects by their name using regex')
   .action(async (args) => {
     try {
@@ -50,6 +59,9 @@ program
         editorsFilter: args.editorsFilter,
         languagesFilter: args.languagesFilter,
         projectsFilter: args.projectsFilter,
+        showEditors: args.showEditors,
+        showLanguages: args.showLanguages,
+        showProjects: args.showProjects,
       });
     } catch (error) {
       console.error('😞  Rut ro, an error occurred');
@@ -60,8 +72,11 @@ program
 program
   .command('week')
   .description('Get Summary for Week')
+  .option('-E, --showEditors', 'Show editors section')
   .option('-e, --editorsFilter <editorFilter>', 'Filter editors by their name using regex')
+  .option('-L, --showLanguages', 'Show languages section')
   .option('-l, --languagesFilter <languagesFilter>', 'Filters languages by their name using regex')
+  .option('-P, --showProjects', 'Show projects section')
   .option('-p, --projectsFilter <projectsFilter', 'Filters projects by their name using regex')
   .action(async (args) => {
     try {
@@ -69,6 +84,9 @@ program
         editorsFilter: args.editorsFilter,
         languagesFilter: args.languagesFilter,
         projectsFilter: args.projectsFilter,
+        showEditors: args.showEditors,
+        showLanguages: args.showLanguages,
+        showProjects: args.showProjects,
       });
     } catch (error) {
       console.error('😞  Rut ro, an error occurred');

--- a/src/getDailySummary.js
+++ b/src/getDailySummary.js
@@ -10,6 +10,9 @@ const getDailySummary = async ({
   editorsFilter = null,
   languagesFilter = null,
   projectsFilter = null,
+  showEditors = null,
+  showLanguages = null,
+  showProjects = null,
 }) => {
   let apiKey = await get();
 
@@ -61,6 +64,9 @@ const getDailySummary = async ({
     editors,
     languages,
     projects,
+    showEditors,
+    showLanguages,
+    showProjects,
   }));
 };
 

--- a/src/getWeeklySummary.js
+++ b/src/getWeeklySummary.js
@@ -8,6 +8,9 @@ const getWeeklySummary = async ({
   editorsFilter = null,
   languagesFilter = null,
   projectsFilter = null,
+  showEditors = null,
+  showLanguages = null,
+  showProjects = null,
 }) => {
   let apiKey = await get();
 
@@ -33,6 +36,9 @@ const getWeeklySummary = async ({
     editorsFilter,
     languagesFilter,
     projectsFilter,
+    showEditors,
+    showLanguages,
+    showProjects,
   });
 };
 

--- a/src/services/generateDailySummary.js
+++ b/src/services/generateDailySummary.js
@@ -10,13 +10,26 @@ const generateDailySummary = ({
   editors,
   languages,
   projects,
+  showEditors = null,
+  showLanguages = null,
+  showProjects = null,
 }) => {
+  const showAllSections = showEditors == null && showLanguages == null && showProjects == null;
+
   console.log(chalk.cyan.bold(`⏳  Total for ${range.date}`));
   console.log(`${chalk.magenta.bold(grandTotal.text)}\n`);
 
-  generateSection({ name: '✍️  Editors', data: editors });
-  generateSection({ name: '🗣️  Languages', data: languages });
-  generateSection({ name: '🚀  Projects', data: projects });
+  if (showAllSections || (!showAllSections && showEditors)) {
+    generateSection({ name: '✍️  Editors', data: editors });
+  }
+
+  if (showAllSections || (!showAllSections && showLanguages)) {
+    generateSection({ name: '🗣️  Languages', data: languages });
+  }
+
+  if (showAllSections || (!showAllSections && showProjects)) {
+    generateSection({ name: '🚀  Projects', data: projects });
+  }
 };
 
 export default generateDailySummary;

--- a/src/services/generateWeeklySummary.js
+++ b/src/services/generateWeeklySummary.js
@@ -11,6 +11,9 @@ const generateWeeklySummary = ({
   editorsFilter = null,
   languagesFilter = null,
   projectsFilter = null,
+  showEditors = null,
+  showLanguages = null,
+  showProjects = null,
 }) => {
   const grandTotals = data.map((day) => {
     const {
@@ -48,11 +51,23 @@ const generateWeeklySummary = ({
     .reduce((total, grandTotal) => total + grandTotal.totalSeconds, 0);
   const formattedWeeklyGrandTotal = formatTime(new Date(weeklyGrandTotal * 1000));
 
+  const showAllSections = showEditors == null && showLanguages == null && showProjects == null;
+
   console.log(chalk.cyan.bold(`⏳  Total For Past 7 Days: ${chalk.magenta.bold(formattedWeeklyGrandTotal)}\n`));
+
   generateSection({ name: '📅  By Day', data: grandTotals });
-  generateSection({ name: '✍️  Editors', data: editors });
-  generateSection({ name: '🗣️  Languages', data: languages });
-  generateSection({ name: '🚀  Projects', data: projects });
+
+  if (showAllSections || (!showAllSections && showEditors)) {
+    generateSection({ name: '✍️  Editors', data: editors });
+  }
+
+  if (showAllSections || (!showAllSections && showLanguages)) {
+    generateSection({ name: '🗣️  Languages', data: languages });
+  }
+
+  if (showAllSections || (!showAllSections && showProjects)) {
+    generateSection({ name: '🚀  Projects', data: projects });
+  }
 };
 
 export default generateWeeklySummary;


### PR DESCRIPTION
I _think_ this closes #44.

It adds the ability to display only certain sections by supplying the `-E` (editors), `-L` (languages) and `-P` (projects) option flags.

If no flags are specified, then all sections are displayed.

