### PR TITLE
fix(section): check if data exists for section before printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Here are the following ways to toggle specific sections. If no options are speci
 - `-L` - show the `Languages` section
 - `-P` - show the `Projects` section
 
+If data is not available for a given section, it will _not_ be displayed even if that option was specified.
+
 ### Today's Summary
 
 ```bash

--- a/src/executables/waka.js
+++ b/src/executables/waka.js
@@ -32,11 +32,11 @@ program
 program
   .command('today')
   .description('Get Daily Summary')
-  .option('-E, --showEditors', 'Show editors section')
+  .option('-E, --showEditors', 'Show editors section, if data is available')
   .option('-e, --editorsFilter <editorFilter>', 'Filter editors by their name using regex')
-  .option('-L, --showLanguages', 'Show languages section')
+  .option('-L, --showLanguages', 'Show languages section, if data is available')
   .option('-l, --languagesFilter <languagesFilter>', 'Filters languages by their name using regex')
-  .option('-P, --showProjects', 'Show projects section')
+  .option('-P, --showProjects', 'Show projects section, if data is available')
   .option('-p, --projectsFilter <projectsFilter', 'Filters projects by their name using regex')
   .action(async (args) => {
     try {
@@ -57,11 +57,11 @@ program
 program
   .command('yesterday')
   .description('Get Summary for Yesterday')
-  .option('-E, --showEditors', 'Show editors section')
+  .option('-E, --showEditors', 'Show editors section, if data is available')
   .option('-e, --editorsFilter <editorFilter>', 'Filter editors by their name using regex')
-  .option('-L, --showLanguages', 'Show languages section')
+  .option('-L, --showLanguages', 'Show languages section, if data is available')
   .option('-l, --languagesFilter <languagesFilter>', 'Filters languages by their name using regex')
-  .option('-P, --showProjects', 'Show projects section')
+  .option('-P, --showProjects', 'Show projects section, if data is available')
   .option('-p, --projectsFilter <projectsFilter', 'Filters projects by their name using regex')
   .action(async (args) => {
     try {
@@ -85,11 +85,11 @@ program
 program
   .command('week')
   .description('Get Summary for Week')
-  .option('-E, --showEditors', 'Show editors section')
+  .option('-E, --showEditors', 'Show editors section, if data is available')
   .option('-e, --editorsFilter <editorFilter>', 'Filter editors by their name using regex')
-  .option('-L, --showLanguages', 'Show languages section')
+  .option('-L, --showLanguages', 'Show languages section, if data is available')
   .option('-l, --languagesFilter <languagesFilter>', 'Filters languages by their name using regex')
-  .option('-P, --showProjects', 'Show projects section')
+  .option('-P, --showProjects', 'Show projects section, if data is available')
   .option('-p, --projectsFilter <projectsFilter', 'Filters projects by their name using regex')
   .action(async (args) => {
     try {

--- a/src/services/generateDailySummary.js
+++ b/src/services/generateDailySummary.js
@@ -3,6 +3,7 @@
 import chalk from 'chalk';
 
 import generateSection from './generateSection';
+import shouldGenerateSection from './shouldGenerateSection';
 
 const generateDailySummary = ({
   grandTotal,
@@ -19,15 +20,23 @@ const generateDailySummary = ({
   console.log(chalk.cyan.bold(`⏳  Total for ${range.date}`));
   console.log(`${chalk.magenta.bold(grandTotal.text)}\n`);
 
-  if (showAllSections || (!showAllSections && showEditors)) {
+  if (shouldGenerateSection({ data: editors, showAllSections, showSpecificSection: showEditors })) {
     generateSection({ name: '✍️  Editors', data: editors });
   }
 
-  if (showAllSections || (!showAllSections && showLanguages)) {
+  if (shouldGenerateSection({
+    data: languages,
+    showAllSections,
+    showSpecificSection: showLanguages,
+  })) {
     generateSection({ name: '🗣️  Languages', data: languages });
   }
 
-  if (showAllSections || (!showAllSections && showProjects)) {
+  if (shouldGenerateSection({
+    data: projects,
+    showAllSections,
+    showSpecificSection: showProjects,
+  })) {
     generateSection({ name: '🚀  Projects', data: projects });
   }
 };

--- a/src/services/generateWeeklySummary.js
+++ b/src/services/generateWeeklySummary.js
@@ -2,6 +2,7 @@
 
 import chalk from 'chalk';
 import generateSection from './generateSection';
+import shouldGenerateSection from './shouldGenerateSection';
 import formatTime from './formatTime';
 import aggregateDailyStatistics from './aggregateDailyStatistics';
 import formatAggregatedStatistics from './formatAggregatedStatistics';
@@ -57,15 +58,25 @@ const generateWeeklySummary = ({
 
   generateSection({ name: '📅  By Day', data: grandTotals });
 
-  if (showAllSections || (!showAllSections && showEditors)) {
+  // TODO @jaebradley: consolidate this with generateDailySummary
+
+  if (shouldGenerateSection({ data: editors, showAllSections, showSpecificSection: showEditors })) {
     generateSection({ name: '✍️  Editors', data: editors });
   }
 
-  if (showAllSections || (!showAllSections && showLanguages)) {
+  if (shouldGenerateSection({
+    data: languages,
+    showAllSections,
+    showSpecificSection: showLanguages,
+  })) {
     generateSection({ name: '🗣️  Languages', data: languages });
   }
 
-  if (showAllSections || (!showAllSections && showProjects)) {
+  if (shouldGenerateSection({
+    data: projects,
+    showAllSections,
+    showSpecificSection: showProjects,
+  })) {
     generateSection({ name: '🚀  Projects', data: projects });
   }
 };

--- a/src/services/shouldGenerateSection.js
+++ b/src/services/shouldGenerateSection.js
@@ -1,0 +1,7 @@
+export default function shouldGenerateSection({
+  data,
+  showAllSections,
+  showSpecificSection,
+}) {
+  return data && Object.keys(data).length && (showAllSections || showSpecificSection);
+}


### PR DESCRIPTION
Resolves #65.

Before printing a section ensure that data exists. I considered logging a message about a certain section's data not existing, but ultimately decided against it.

Updated both the `README` and the option descriptions for `today`, `yesterday`, and `week` to reflect this.